### PR TITLE
strip out word senses and include them in results

### DIFF
--- a/lib/lib/process-html.js
+++ b/lib/lib/process-html.js
@@ -60,10 +60,15 @@ function createTranslationItem (html) {
   var toType = $('.ToWrd em').text()
   $('.ToWrd em').remove()
   var to = $('.ToWrd').text()
+  var [fromSense, toSense] = $('.FrWrd')[0].nextSibling.children
+  fromSense = $(fromSense).text().trim()
+  toSense = $(toSense).text().trim()
   return {
     from,
     fromType,
+    fromSense,
     toType,
+    toSense,
     to,
     example: {
       from: [],


### PR DESCRIPTION
WordReference provides word "senses" and this PR parses those out of the markup returned and includes them in the JSON returned. In the screenshot below, this would mean returning "(ensemble des règles)" as `fromSense` and "(official rules)" as `toSense`
<img width="527" alt="Screen Shot 2019-07-04 at 12 58 14 PM" src="https://user-images.githubusercontent.com/114348/60686032-7265d680-9e5b-11e9-84c9-195770096094.png">
